### PR TITLE
Use name initials as avatar

### DIFF
--- a/src/components/Avatar.tsx
+++ b/src/components/Avatar.tsx
@@ -1,0 +1,16 @@
+import React from "react"
+
+export declare type AvatarPros = {
+  name: string;
+};
+
+export const Avatar = ({name}: AvatarPros): JSX.Element => {
+  const [f, l]: string[] = name.split(' ')
+  const initials = [f.charAt(0).toUpperCase(), (l || '').charAt(0).toUpperCase()].join('')
+
+  return (
+    <div className="border-primary rounded-full bg-purple-light text-success w-10 h-10 mr-3 inline-flex items-center align-middle justify-center font-nunito text-md">
+      {initials}
+    </div>
+  )
+}

--- a/src/components/SessionSection.tsx
+++ b/src/components/SessionSection.tsx
@@ -1,4 +1,5 @@
 import { SurveyResponse } from "models/SurveyResponse"
+import { Avatar } from "./Avatar"
 import React from "react"
 import { useQuery } from "@apollo/client"
 import { GetSurveyResponsesQuery } from "graphql/queries/GetSurveyResponses"
@@ -30,7 +31,7 @@ export const SessionSection = (): JSX.Element => {
           <React.Fragment key={response.id}>
             <div className="px-2">
               <div className="w-full flex flex-row inline-block text-left my-2 shadow border rounded py-2 px-3 text-gray-700 leading-tight border-blue-300 bg-blue-50">
-                <img src="" className="text-center rounded-full bg-red-200 w-10 h-10 inline-block mr-3 inline-block" />
+                <Avatar name={name} />
                 <div className="inline-block flex flex-col">
                   <p className="block">{name}</p>
                   <p className="block text-xs">{date}</p>

--- a/src/components/StudentSection.tsx
+++ b/src/components/StudentSection.tsx
@@ -1,4 +1,5 @@
 import { Student } from "models/Student"
+import { Avatar } from "./Avatar"
 import React from "react"
 interface StudentSectionProps {
   students: Student[];
@@ -14,7 +15,7 @@ export const StudentSection = ({
           <React.Fragment key={student.id}>
             <div className="px-2">
               <div className="flex flex-row w-full inline-block text-left my-2 shadow border rounded py-2 px-3 text-gray-700 leading-tight border-green-300 bg-green-50">
-                <img src="" className="text-center rounded-full bg-red-200 w-10 h-10 inline-block mr-3 inline-block" />
+                <Avatar name={student.name} />
                 <div className="inline-block flex flex-col ">
                   <p className="block">{student.name}</p>
                   <p className="block text-xs">{student.dateOfBirth}</p>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,6 +2,11 @@ module.exports = {
   purge: ["./src/**/*.{js,jsx,ts,tsx}", "./public/index.html"],
   darkMode: false,
   theme: {
+    colors: {
+      purple: {
+        light: "#d1c4e9",
+      },
+    },
     extend: {},
     fontFamily: {
       'nunito': ['nunito', 'sans-serif']


### PR DESCRIPTION
Resolves #16

### Description

Replace broken images by an avatar using the student's initials.

### Type of change

- New feature (non-breaking change which adds functionality)

### Screenshots

![image](https://user-images.githubusercontent.com/84035/136882577-d08f32bd-df94-4c93-8194-7c3562a91eb5.png)
