### PR TITLE
Fix HTML class property

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -27,7 +27,7 @@
     -->
     <title>InKind</title>
   </head>
-  <body className="font-nunito">
+  <body class="font-nunito">
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
     <!--


### PR DESCRIPTION
### Description

Fix the HTML class property used at the initial HTML file. 
This is a regular HTML file and should use `class` instead of the React property `className`.
The typo was avoiding the classes being applied.

### Type of change

- Bug fix (non-breaking change which fixes an issue)
