### PR TITLE
Resolves EsLint/Type warnings

### DIFF
--- a/src/lib/authentication.ts
+++ b/src/lib/authentication.ts
@@ -1,8 +1,8 @@
 import { setContext } from '@apollo/client/link/context'
 
 const TokenKey = 'in-kind-app-token'
-const getToken = () => localStorage.getItem(TokenKey)
-const setToken = (token: string) => localStorage.setItem(TokenKey, token)
+const getToken = (): string | null => localStorage.getItem(TokenKey)
+const setToken = (token: string): void => localStorage.setItem(TokenKey, token)
 
 const authenticatedHttpLink = setContext((_, { headers }) => {
   const token = getToken()


### PR DESCRIPTION
### Description

Resolves lint warnings

Before:

```
src/lib/authentication.ts
  Line 4:18:  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
  Line 5:18:  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
```

After:

```
```